### PR TITLE
add sanitzation for student responses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,12 +8,21 @@ anyio==4.12.1
     # via
     #   httpx
     #   starlette
+attrs==26.1.0
+    # via aws-encryption-sdk
+aws-encryption-sdk==4.0.5
+    # via aws-lambda-powertools
 aws-lambda-powertools==3.24.0
     # via grading-helper-service
+aws-xray-sdk==2.15.0
+    # via aws-lambda-powertools
 boto3==1.42.43
-    # via grading-helper-service
+    # via
+    #   aws-encryption-sdk
+    #   grading-helper-service
 botocore==1.42.43
     # via
+    #   aws-xray-sdk
     #   boto3
     #   s3transfer
 certifi==2025.10.5
@@ -23,9 +32,13 @@ certifi==2025.10.5
 cffi==2.0.0 ; platform_python_implementation != 'PyPy'
     # via cryptography
 cryptography==46.0.4
-    # via grading-helper-service
+    # via
+    #   aws-encryption-sdk
+    #   grading-helper-service
 fastapi==0.128.3
     # via grading-helper-service
+fastjsonschema==2.21.2
+    # via aws-lambda-powertools
 h11==0.16.0
     # via httpcore
 httpcore==1.0.9
@@ -41,19 +54,24 @@ jmespath==1.1.0
     #   aws-lambda-powertools
     #   boto3
     #   botocore
+jsonpath-ng==1.8.0
+    # via aws-lambda-powertools
 mangum==0.21.0
     # via grading-helper-service
 pycparser==3.0 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'
     # via cffi
 pydantic==2.12.5
     # via
+    #   aws-lambda-powertools
     #   fastapi
     #   grading-helper-service
     #   pydantic-settings
 pydantic-core==2.41.5
     # via pydantic
 pydantic-settings==2.12.0
-    # via grading-helper-service
+    # via
+    #   aws-lambda-powertools
+    #   grading-helper-service
 pyjwt==2.11.0
     # via grading-helper-service
 python-dateutil==2.9.0.post0
@@ -83,3 +101,7 @@ typing-inspection==0.4.2
     #   pydantic-settings
 urllib3==2.5.0
     # via botocore
+wrapt==2.1.2
+    # via
+    #   aws-encryption-sdk
+    #   aws-xray-sdk

--- a/src/lti/routes.py
+++ b/src/lti/routes.py
@@ -1,6 +1,7 @@
 """LTI 1.3 endpoints: OIDC login, launch, JWKS, tool configuration, and Canvas integration."""
 
 from html import escape
+import re
 from urllib.parse import urlencode
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
@@ -197,6 +198,16 @@ def lti_config():
 
 
 # --- Canvas integration routes ---
+def _sanitize_answer(text: str) -> str:
+    """
+    Strip Latex commands and escape backslashes to sanitize student answers
+    """
+    if not text:
+        return ""
+    text = text.replace("\\", "\\\\")
+    text = re.sub(r"\\[a-zA-Z]+", "", text)
+    text = re.sub(r"[\x00-\x08\x0b-\x0c\x0e-\x1f]", "", text)
+    return text.strip()
 
 
 def _extract_answers(submission_data: list[dict]) -> list[dict]:
@@ -210,14 +221,14 @@ def _extract_answers(submission_data: list[dict]) -> list[dict]:
     for item in submission_data:
         question_id = item.get("question_id")
         # Primary answer field
-        answer = item.get("text", "")
+        answer = _sanitize_answer(item.get("text", ""))
 
         # For fill_in_multiple_blanks, text is empty — collect answer_for_* fields
         if not answer:
             blank_answers = []
             for key, value in item.items():
                 if key.startswith("answer_for_") and value:
-                    blank_answers.append(str(value))
+                    blank_answers.append(_sanitize_answer(str(value)))
             if blank_answers:
                 answer = "; ".join(blank_answers)
 

--- a/src/lti/routes.py
+++ b/src/lti/routes.py
@@ -23,6 +23,8 @@ from src.lti.ui import render_instructor_ui
 
 router = APIRouter(prefix="/lti", tags=["lti"])
 jwks_router = APIRouter(tags=["lti"])
+LATEX_PATTERN = re.compile(r"\\[a-zA-Z]+")
+CONTROL_CHARACTER_PATTERN = re.compile(r"[\x00-\x08\x0b-\x0c\x0e-\x1f]")
 
 
 @router.get("/login")
@@ -205,8 +207,8 @@ def _sanitize_answer(text: str) -> str:
     if not text:
         return ""
     text = text.replace("\\", "\\\\")
-    text = re.sub(r"\\[a-zA-Z]+", "", text)
-    text = re.sub(r"[\x00-\x08\x0b-\x0c\x0e-\x1f]", "", text)
+    text = LATEX_PATTERN.sub("", text)
+    text = CONTROL_CHARACTER_PATTERN.sub("", text)
     return text.strip()
 
 

--- a/src/services/grading.py
+++ b/src/services/grading.py
@@ -132,6 +132,26 @@ class GradingService:
                 "max_tokens": 512,
                 "temperature": 0,
                 "messages": [{"role": "user", "content": prompt}],
+                "output_config": {
+                    "format": {
+                        "type": "json_schema",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "grade": {
+                                    "type": "number",
+                                    "description": "points awarded to student based on their answer, limited to maximum points possible",
+                                },
+                                "feedback": {
+                                    "type": "string",
+                                    "description": "feedback for student explaining why their answer is correct or incorrect",
+                                },
+                            },
+                            "required": ["grade", "feedback"],
+                            "additionalProperties": False,
+                        },
+                    }
+                },
             }
         )
         response = self.bedrock_client.invoke_model(
@@ -160,7 +180,15 @@ class GradingService:
                 lines = lines[:-1]
             text = "\n".join(lines)
 
-        parsed = json.loads(text)
+        try:
+            parsed = json.loads(text)
+        except Exception as e:
+            logger.error(
+                "Failed to parse Bedrock response text",
+                raw_text=text,
+                error=f"{e.__class__.__name__} {e}",
+            )
+            raise
         grade = float(parsed["grade"])
         feedback = str(parsed["feedback"])
 

--- a/src/services/grading.py
+++ b/src/services/grading.py
@@ -66,14 +66,15 @@ class GradingService:
                 sub = futures[future]
                 try:
                     future.result()
-                except Exception as e:
-                    logger.error(
+                except Exception:
+                    logger.exception(
                         "Grading submission failed",
                         job_id=str(job_id),
                         submission_id=str(sub.submission_id),
-                        error=str(e),
                     )
-                    errors.append(f"Submission {sub.submission_id}: {e}")
+                    errors.append(
+                        f"Submission {sub.submission_id}: Failed to grade submission"
+                    )
 
         if errors:
             logger.warning(
@@ -182,11 +183,10 @@ class GradingService:
 
         try:
             parsed = json.loads(text)
-        except Exception as e:
-            logger.error(
+        except Exception:
+            logger.exception(
                 "Failed to parse Bedrock response text",
                 raw_text=text,
-                error=f"{e.__class__.__name__} {e}",
             )
             raise
         grade = float(parsed["grade"])

--- a/tests/test_grading_service.py
+++ b/tests/test_grading_service.py
@@ -118,7 +118,7 @@ class TestGradeJob:
 
         updated_job = job_repo.get(job.job_id)
         assert updated_job.status == JobStatus.FAILED
-        assert "Bedrock error" in updated_job.error_message
+        assert "Failed to grade submission" in updated_job.error_message
 
     def test_cancel_pending_job(self, dynamodb_table):
         job_repo = GradingJobRepository(table=dynamodb_table)

--- a/tests/test_lti_routes.py
+++ b/tests/test_lti_routes.py
@@ -13,6 +13,7 @@ from moto import mock_aws
 from src.api.app import create_app
 from src.auth.session import _get_public_key
 from src.lti.key_manager import get_private_key, get_public_jwk
+from src.lti.routes import _extract_answers
 
 
 @pytest.fixture
@@ -493,3 +494,64 @@ class TestPassback:
 
         assert response.status_code == 401
         assert "Re-authorize" in response.json()["detail"]
+
+
+class TestExtractAnswers:
+    """Tests for _extract_answers function."""
+
+    def test_basic_text_answer(self):
+        submission_data = [{"question_id": 1, "text": "The sweet gum tree"}]
+        result = _extract_answers(submission_data)
+        assert result == [{"question_id": 1, "answer": "The sweet gum tree"}]
+
+    def test_latex_answer_is_sanitized(self):
+        submission_data = [{"question_id": 2, "text": r"f(\alpha\placeholder)"}]
+        result = _extract_answers(submission_data)
+        assert "\\placeholder" not in result[0]["answer"]
+        assert "\\alpha" not in result[0]["answer"]
+
+    def test_fill_in_blank_answer(self):
+        submission_data = [
+            {
+                "question_id": 3,
+                "text": "",
+                "answer_for_blank1": "photosynthesis",
+                "answer_for_blank2": "chlorophyll",
+            }
+        ]
+        result = _extract_answers(submission_data)
+        assert result[0]["question_id"] == 3
+        assert "photosynthesis" in result[0]["answer"]
+        assert "chlorophyll" in result[0]["answer"]
+
+    def test_fill_in_blank_answer_is_sanitized(self):
+        submission_data = [
+            {
+                "question_id": 4,
+                "text": "",
+                "answer_for_blank1": r"\alpha value",
+            }
+        ]
+        result = _extract_answers(submission_data)
+        assert "\\alpha" not in result[0]["answer"]
+
+    def test_empty_text_and_no_blanks(self):
+        submission_data = [{"question_id": 5, "text": ""}]
+        result = _extract_answers(submission_data)
+        assert result == [{"question_id": 5, "answer": ""}]
+
+    def test_multiple_submissions(self):
+        submission_data = [
+            {"question_id": 1, "text": "A piano"},
+            {"question_id": 2, "text": "The letter M"},
+        ]
+        result = _extract_answers(submission_data)
+        assert len(result) == 2
+        assert result[0] == {"question_id": 1, "answer": "A piano"}
+        assert result[1] == {"question_id": 2, "answer": "The letter M"}
+
+    def test_missing_question_id(self):
+        submission_data = [{"text": "some answer"}]
+        result = _extract_answers(submission_data)
+        assert result[0]["question_id"] is None
+        assert result[0]["answer"] == "some answer"


### PR DESCRIPTION
# Summary

Student answers containing LaTeX or mathematical expressions were previously stored and sent directly to Bedrock without sanitization. This could result in malformed JSON responses from Bedrock, causing the entire grading job to fail. These changes sanitize student answers during Canvas ingestion before they are sent for grading.

# Changes
- Added a _sanitize_answer helper to escape backslashes, strip LaTeX commands, and remove control characters from student answers 
- Updated _extract_answers to sanitize student responses
- Added TestExtractAnswers test cases to cover extraction and sanitization of student answers