### PR TITLE
Add human in the loop feature

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -166,8 +166,7 @@ Lets instructor set or clear a grade/feedback override on a single submission.
 - **Auth:** Required
 - **Errors:** 404 if job or submission not found, 403 if wrong course, 422 if grade is out of range
 
-**Response:** Updated `Submission` object
-
+**Request body example**
 ```json
 {
   "grade": 8.5,
@@ -175,6 +174,8 @@ Lets instructor set or clear a grade/feedback override on a single submission.
   "revert": false
 }
 ```
+
+**Response:** Updated `Submission` object
 
 ---
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -155,6 +155,15 @@ List all submissions for a grading job, including AI grades and feedback if grad
 ]
 ```
 
+### `PATCH /jobs/{job_id}/submissions/{submissions_id}`
+
+Lets instructor set or clear a grade/feedback override on a single submission.
+
+- **Auth:** Required
+- **Errors:** 404 if job or submission not found, 403 if wrong course, 422 if grade is out of range
+
+**Response:** Updated of `Submission` object
+
 ---
 
 ## LTI Endpoints

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -150,19 +150,31 @@ List all submissions for a grading job, including AI grades and feedback if grad
     "canvas_user_id": "42",
     "ai_grade": 4.5,
     "ai_feedback": "Good understanding of the core concept...",
-    "ai_graded_at": "2026-03-10T15:35:00+00:00"
+    "ai_graded_at": "2026-03-10T15:35:00+00:00",
+    "instructor_grade": 5.0,
+    "instructor_feedback": "Excellent explanation.",
+    "effective_grade": 5.0,
+    "effective_feedback": "Excellent explanation."
   }
 ]
 ```
 
-### `PATCH /jobs/{job_id}/submissions/{submissions_id}`
+### `PATCH /jobs/{job_id}/submissions/{submission_id}`
 
 Lets instructor set or clear a grade/feedback override on a single submission.
 
 - **Auth:** Required
 - **Errors:** 404 if job or submission not found, 403 if wrong course, 422 if grade is out of range
 
-**Response:** Updated of `Submission` object
+**Response:** Updated `Submission` object
+
+```json
+{
+  "grade": 8.5,
+  "feedback": "Good explanation. Added points for the correct example.",
+  "revert": false
+}
+```
 
 ---
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -166,7 +166,7 @@ Lets instructor set or clear a grade/feedback override on a single submission.
 - **Auth:** Required
 - **Errors:** 404 if job or submission not found, 403 if wrong course, 422 if grade is out of range
 
-**Request body example**
+**Request body example:**
 ```json
 {
   "grade": 8.5,

--- a/docs/data-models/index.md
+++ b/docs/data-models/index.md
@@ -42,6 +42,8 @@ erDiagram
         string ai_grade
         string ai_feedback
         string ai_graded_at
+        string insructor_grade
+        string insructor_feedback
     }
 
     LTIState {
@@ -191,6 +193,12 @@ One student answer to one question. Defined in `src/models/submission.py`.
 | `ai_grade` | `float | None` | AI-assigned grade (clamped to 0..points_possible) |
 | `ai_feedback` | `str | None` | AI-generated feedback text |
 | `ai_graded_at` | `datetime | None` | When the AI grading was performed |
+| `insructor_grade` | `float | None` | Grade set by instructor override, replaces AI grade when present |
+| `insructor_feedback` | `str | None` | feedback set by instructor override. replaces AI feedback when present |
+| `effective_grade` | `float | None` | Returns instructor grade if set, otherwise AI grade|
+| `effective_feedback` | `str | None` | Returns instructor feedback if set, otherwise AI feedback |
+| `overridden_by` | `str | None` | Canvas user ID of the instructor/TA who performed the override |
+| `overridden_at` | `datetime | None` | When the Instructor override was done |
 
 ### SessionUser
 

--- a/docs/data-models/index.md
+++ b/docs/data-models/index.md
@@ -42,8 +42,8 @@ erDiagram
         string ai_grade
         string ai_feedback
         string ai_graded_at
-        string insructor_grade
-        string insructor_feedback
+        string instructor_grade
+        string instructor_feedback
     }
 
     LTIState {
@@ -146,7 +146,7 @@ Represents a batch grading run for a quiz. Defined in `src/models/grading_job.py
 | `quiz_id` | `str` | Canvas quiz ID |
 | `assignment_id` | `str` | Canvas assignment ID (used for AGS lineitem matching) |
 | `job_name` | `str` | Human-readable name |
-| `status` | `JobStatus` | `PENDING`, `PROCESSING`, `COMPLETED`, or `FAILED` |
+| `status` | `JobStatus` | `PENDING`, `PROCESSING`, `COMPLETED`, `FAILED`, or `CANCELLED` |
 | `total_questions` | `int` | Number of questions in the quiz |
 | `total_submissions` | `int` | Number of student submissions |
 | `created_at` | `datetime` | UTC timestamp |
@@ -161,6 +161,7 @@ Represents a batch grading run for a quiz. Defined in `src/models/grading_job.py
 - `PROCESSING` — Bedrock calls in progress
 - `COMPLETED` — all submissions graded successfully
 - `FAILED` — one or more submissions failed to grade (error_message has details)
+- `CANCELLED` — job cancelled successfully
 
 ### GradingJobCreate
 

--- a/docs/data-models/index.md
+++ b/docs/data-models/index.md
@@ -101,6 +101,8 @@ erDiagram
 | Get launch context | `pk=LAUNCH#{id}`, `sk=LAUNCH` | `LaunchStore.get()` |
 | Get Canvas OAuth token | `pk=CANVAS_TOKEN#{user}`, `sk=COURSE#{course}` | `get_canvas_token()` |
 | Check instructor role | `pk=LAUNCH#{launch_id}`, `sk=LAUNCH` | `require_instructor()` |
+| Set instructor override | `pk=JOB#{job_id}`, `sk=SUB#{sub_id}` | `SubmissionRepository.set_override()` |
+| Clear instructor override | `pk=JOB#{job_id}`, `sk=SUB#{sub_id}` | `SubmissionRepository.clear_override()` |
 
 ## GSI Design
 
@@ -115,7 +117,7 @@ erDiagram
 
 - **Partition key:** `GSI2PK` = `STATUS#{status}`
 - **Sort key:** `GSI2SK` = `JOB#{job_id}`
-- **Used by:** `list_by_status()` to find jobs in a specific state (PENDING, PROCESSING, COMPLETED, FAILED)
+- **Used by:** `list_by_status()` to find jobs in a specific state (PENDING, PROCESSING, COMPLETED, FAILED, CANCELLED)
 - **Projection:** ALL
 - **Note:** When a job's status changes, the repository updates `GSI2PK` in the same `update_item` call so the GSI stays consistent
 
@@ -193,8 +195,8 @@ One student answer to one question. Defined in `src/models/submission.py`.
 | `ai_grade` | `float | None` | AI-assigned grade (clamped to 0..points_possible) |
 | `ai_feedback` | `str | None` | AI-generated feedback text |
 | `ai_graded_at` | `datetime | None` | When the AI grading was performed |
-| `insructor_grade` | `float | None` | Grade set by instructor override, replaces AI grade when present |
-| `insructor_feedback` | `str | None` | feedback set by instructor override. replaces AI feedback when present |
+| `instructor_grade` | `float | None` | Grade set by instructor override, replaces AI grade when present |
+| `instructor_feedback` | `str | None` | feedback set by instructor override. replaces AI feedback when present |
 | `effective_grade` | `float | None` | Returns instructor grade if set, otherwise AI grade|
 | `effective_feedback` | `str | None` | Returns instructor feedback if set, otherwise AI feedback |
 | `overridden_by` | `str | None` | Canvas user ID of the instructor/TA who performed the override |

--- a/docs/data-models/index.md
+++ b/docs/data-models/index.md
@@ -192,15 +192,15 @@ One student answer to one question. Defined in `src/models/submission.py`.
 | `canvas_user_id` | `str` | Canvas user ID (for grade passback) |
 | `quiz_submission_id` | `int` | Canvas quiz submission ID (used for REST-based grade passback; 0 if not set) |
 | `attempt` | `int` | Quiz submission attempt number (default 1) |
-| `ai_grade` | `float | None` | AI-assigned grade (clamped to 0..points_possible) |
-| `ai_feedback` | `str | None` | AI-generated feedback text |
-| `ai_graded_at` | `datetime | None` | When the AI grading was performed |
-| `instructor_grade` | `float | None` | Grade set by instructor override, replaces AI grade when present |
-| `instructor_feedback` | `str | None` | feedback set by instructor override. replaces AI feedback when present |
-| `effective_grade` | `float | None` | Returns instructor grade if set, otherwise AI grade|
-| `effective_feedback` | `str | None` | Returns instructor feedback if set, otherwise AI feedback |
-| `overridden_by` | `str | None` | Canvas user ID of the instructor/TA who performed the override |
-| `overridden_at` | `datetime | None` | When the Instructor override was done |
+| `ai_grade` | `float \| None` | AI-assigned grade (clamped to 0..points_possible) |
+| `ai_feedback` | `str \| None` | AI-generated feedback text |
+| `ai_graded_at` | `datetime \| None` | When the AI grading was performed |
+| `instructor_grade` | `float \| None` | Grade set by instructor override, replaces AI grade when present |
+| `instructor_feedback` | `str \| None` | feedback set by instructor override. replaces AI feedback when present |
+| `effective_grade` | `float \| None` | Returns instructor grade if set, otherwise AI grade|
+| `effective_feedback` | `str \| None` | Returns instructor feedback if set, otherwise AI feedback |
+| `overridden_by` | `str \| None` | Canvas user ID of the instructor/TA who performed the override |
+| `overridden_at` | `datetime \| None` | When the Instructor override was done |
 
 ### SessionUser
 

--- a/src/api/routes/jobs.py
+++ b/src/api/routes/jobs.py
@@ -3,10 +3,11 @@
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import ValidationError
+from pydantic import ValidationError, BaseModel
 
 from src.auth.session import SessionUser, require_instructor
 from src.core.observability import logger, metrics, MetricUnit
+from src.core.validation import validate_grade
 from src.models.grading_job import GradingJob, GradingJobCreate, JobStatus
 from src.models.submission import Submission
 from src.repositories.grading_job import GradingJobRepository
@@ -165,8 +166,6 @@ def list_submissions(
     return sub_repo.list_by_job(job_id)
 
 
-from src.core.validation import validate_grade
-
 class SubmissionOverrideRequest(BaseModel):
     grade: float | None = None
     feedback: str | None = None
@@ -177,8 +176,8 @@ class SubmissionOverrideRequest(BaseModel):
 def override_submission(
     job_id: UUID,
     submission_id: UUID,
-    body: SubmissionOverride,
-    session: SessionUser = Depends(require_session),
+    body: SubmissionOverrideRequest,
+    session: SessionUser = Depends(require_instructor),
 ) -> Submission:
     """Set or clear an instructor override on a submission's grade/feedback."""
     job_repo = _get_job_repo()
@@ -198,24 +197,29 @@ def override_submission(
     if submission is None:
         raise HTTPException(status_code=404, detail="Submission not found")
 
-    if (
-        body.grade is None
-        and body.feedback is None
-        and not body.revert
-    ):
-        raise HTTPException(
-            status_code=422,
-            detail="Nothing to update.",
-        )
+    if body.grade is None and body.feedback is None and not body.revert:
+        raise HTTPException(status_code=422, detail="Nothing to update.")
 
     if body.revert:
-        return sub_repo.clear_override(job_id, submission_id)
+        updated = sub_repo.clear_override(job_id, submission_id)
+        if updated is None:
+            raise HTTPException(status_code=404, detail="Submission not found")
+        return updated
 
     if body.grade is not None:
         error = validate_grade(body.grade, submission.points_possible)
         if error:
             raise HTTPException(status_code=422, detail=error)
 
-    return sub_repo.set_override(
-        job_id, submission_id, body.grade, body.feedback, session.canvas_user_id
+    updated = sub_repo.set_override(
+        job_id,
+        submission_id,
+        body.grade,
+        body.feedback,
+        session.canvas_user_id,
     )
+
+    if updated is None:
+        raise HTTPException(status_code=404, detail="Submission not found")
+
+    return updated

--- a/src/api/routes/jobs.py
+++ b/src/api/routes/jobs.py
@@ -149,3 +149,49 @@ def list_submissions(
 
     sub_repo = _get_sub_repo()
     return sub_repo.list_by_job(job_id)
+
+
+# from src.core.validation import validate_grade
+
+# class SubmissionOverride(BaseModel):
+#     grade: float | None = None
+#     feedback: str | None = None
+#     revert: bool = False
+
+
+# @router.patch("/{job_id}/submissions/{submission_id}", response_model=Submission)
+# def override_submission(
+#     job_id: UUID,
+#     submission_id: UUID,
+#     body: SubmissionOverride,
+#     session: SessionUser = Depends(require_session),
+# ) -> Submission:
+#     """Set or clear an instructor override on a submission's grade/feedback."""
+#     job_repo = _get_job_repo()
+#     job = job_repo.get(job_id)
+#     if job is None:
+#         raise HTTPException(status_code=404, detail="Job not found")
+#     if job.course_id != session.course_id:
+#         raise HTTPException(status_code=403, detail="Access denied")
+#     if job.status != JobStatus.COMPLETED:
+#         raise HTTPException(
+#             status_code=409,
+#             detail=f"Job is {job.status}, must be COMPLETED to override a grade",
+#         )
+
+#     sub_repo = _get_sub_repo()
+#     submission = sub_repo.get(job_id, submission_id)
+#     if submission is None:
+#         raise HTTPException(status_code=404, detail="Submission not found")
+
+#     if body.revert:
+#         return sub_repo.clear_override(job_id, submission_id)
+
+#     if body.grade is not None:
+#         error = validate_grade(body.grade, submission.points_possible)
+#         if error:
+#             raise HTTPException(status_code=422, detail=error)
+
+#     return sub_repo.set_override(
+#         job_id, submission_id, body.grade, body.feedback, session.canvas_user_id
+#     )

--- a/src/api/routes/jobs.py
+++ b/src/api/routes/jobs.py
@@ -163,3 +163,59 @@ def list_submissions(
 
     sub_repo = _get_sub_repo()
     return sub_repo.list_by_job(job_id)
+
+
+from src.core.validation import validate_grade
+
+class SubmissionOverrideRequest(BaseModel):
+    grade: float | None = None
+    feedback: str | None = None
+    revert: bool = False
+
+
+@router.patch("/{job_id}/submissions/{submission_id}", response_model=Submission)
+def override_submission(
+    job_id: UUID,
+    submission_id: UUID,
+    body: SubmissionOverride,
+    session: SessionUser = Depends(require_session),
+) -> Submission:
+    """Set or clear an instructor override on a submission's grade/feedback."""
+    job_repo = _get_job_repo()
+    job = job_repo.get(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job.course_id != session.course_id:
+        raise HTTPException(status_code=403, detail="Access denied")
+    if job.status != JobStatus.COMPLETED:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Job is {job.status}, must be COMPLETED to override a grade",
+        )
+
+    sub_repo = _get_sub_repo()
+    submission = sub_repo.get(job_id, submission_id)
+    if submission is None:
+        raise HTTPException(status_code=404, detail="Submission not found")
+
+    if (
+        body.grade is None
+        and body.feedback is None
+        and not body.revert
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail="Nothing to update.",
+        )
+
+    if body.revert:
+        return sub_repo.clear_override(job_id, submission_id)
+
+    if body.grade is not None:
+        error = validate_grade(body.grade, submission.points_possible)
+        if error:
+            raise HTTPException(status_code=422, detail=error)
+
+    return sub_repo.set_override(
+        job_id, submission_id, body.grade, body.feedback, session.canvas_user_id
+    )

--- a/src/api/routes/jobs.py
+++ b/src/api/routes/jobs.py
@@ -200,6 +200,12 @@ def override_submission(
     if body.grade is None and body.feedback is None and not body.revert:
         raise HTTPException(status_code=422, detail="Nothing to update.")
 
+    if body.revert and (body.grade is not None or body.feedback is not None):
+        raise HTTPException(
+            status_code=422,
+            detail="Cannot provide grade or feedback when reverting.",
+        )
+
     if body.revert:
         updated = sub_repo.clear_override(job_id, submission_id)
         if updated is None:
@@ -210,7 +216,11 @@ def override_submission(
         error = validate_grade(body.grade, submission.points_possible)
         if error:
             raise HTTPException(status_code=422, detail=error)
-
+    if body.feedback is not None and not body.feedback.strip():
+        raise HTTPException(
+            status_code=422,
+            detail="Feedback cannot be empty.",
+        )
     updated = sub_repo.set_override(
         job_id,
         submission_id,

--- a/src/core/validation.py
+++ b/src/core/validation.py
@@ -5,6 +5,6 @@ def validate_grade(grade: float, points_possible: float) -> str | None:
     """Returns an error message if invalid, None if valid."""
     if grade < 0:
         return "Grade cannot be negative."
-    if grade > points_possible:  # although some times proffs give extra points...
+    if grade > points_possible:
         return f"Grade cannot exceed {points_possible} points."
     return None

--- a/src/core/validation.py
+++ b/src/core/validation.py
@@ -1,0 +1,10 @@
+# src/core/validation.py
+
+
+def validate_grade(grade: float, points_possible: float) -> str | None:
+    """Returns an error message if invalid, None if valid."""
+    if grade < 0:
+        return "Grade cannot be negative."
+    if grade > points_possible:  # although some times proffs give extra points...
+        return f"Grade cannot exceed {points_possible} points."
+    return None

--- a/src/lti/ags.py
+++ b/src/lti/ags.py
@@ -188,7 +188,7 @@ def passback_quiz_grades_via_rest(
     # Group AI-graded submissions by student (one PUT call per student)
     by_student: dict[tuple, dict] = {}
     for sub in submissions:
-        if sub.ai_grade is None:
+        if sub.effective_grade is None:
             continue
         if sub.quiz_submission_id == 0:
             # Pre-migration row — skip, no quiz_submission_id available
@@ -197,8 +197,8 @@ def passback_quiz_grades_via_rest(
         if key not in by_student:
             by_student[key] = {}
         by_student[key][sub.question_id] = {
-            "score": sub.ai_grade,
-            "comment": sub.ai_feedback or "",
+            "score": sub.effective_grade,
+            "comment": sub.effective_feedback or "",
         }
 
     submitted = 0
@@ -296,16 +296,16 @@ def passback_job_grades(
     errors: list[str] = []
 
     for sub in submissions:
-        if sub.ai_grade is None:
+        if sub.effective_grade is None:
             continue
         try:
             submit_score(
                 lineitem_url=lineitem_url,
                 token=token,
                 user_id=sub.canvas_user_id or str(sub.submission_id),
-                score=sub.ai_grade,
+                score=sub.effective_grade,
                 max_score=sub.points_possible,
-                comment=sub.ai_feedback,
+                comment=sub.effective_feedback,
             )
             submitted += 1
         except Exception as e:

--- a/src/lti/ui.py
+++ b/src/lti/ui.py
@@ -102,9 +102,9 @@ def render_instructor_ui(
     .badge-override {{ background: #e8f0fe; color: #1a56db; font-size: 0.75em; 
                     padding: 1px 6px; border-radius: 10px; margin-left: 4px; }}
     .override-form {{ display: flex; flex-direction: column; gap: 4px; min-width: 160px; }}
-    .override-form input {{ padding: 4px 6px; font-size: 0.85em; border: 1px solid #ccc;
+    .override-form input {{ padding: 4px 6px; font-size: 0.85rem; border: 1px solid #ccc;
                             border-radius: 4px; width: 70px; }}
-    .override-form textarea {{ padding: 4px 6px; font-size: 0.85em; border: 1px solid #ccc;
+    .override-form textarea {{ padding: 4px 6px; font-size: 0.85rem; border: 1px solid #ccc;
                             border-radius: 4px; resize: vertical; width: 100%; }}
     .override-form .btn-row {{ display: flex; gap: 4px; }}
     .btn-save {{ background: #006600; padding: 3px 10px; font-size: 0.82em; }}
@@ -592,6 +592,12 @@ def render_instructor_ui(
           const tdF = document.createElement('td');
           tdF.id = 'feedback-cell-' + sub.submission_id;
           tdF.textContent = stripHtml(sub.effective_feedback) || '\u2014';
+          if (sub.instructor_feedback) {{
+              const feedbackBadge = document.createElement('span');
+              feedbackBadge.className = 'badge-override';
+              feedbackBadge.textContent = 'edited';
+              tdF.appendChild(feedbackBadge);
+          }}
           tr.appendChild(tdF);
 
           const tdO = document.createElement('td');
@@ -607,6 +613,7 @@ def render_instructor_ui(
           ${{isOverridden ? `<button class="btn-revert" onclick="revertOverride('${{currentJobId}}', '${{sub.submission_id}}')">Revert</button>` : ''}}
         </div>
         <div id="override-msg-${{sub.submission_id}}" class="status"></div>
+        ${{isOverridden ? `<div class="override-info" style="font-size:0.8rem; color:#666; margin-top:4px;">Last override by ${{sub.overridden_by || 'unknown'}}</div>` : ''}}
         </div>
         `;
         tr.appendChild(tdO);
@@ -832,9 +839,35 @@ document.getElementById('btn-cancel-grading').addEventListener('click', async ()
             badge.textContent = 'edited';
             gradeCell.appendChild(badge);
             }}
+    
+            const feedbackCell = document.getElementById('feedback-cell-' + submissionId);
+            feedbackCell.textContent = stripHtml(updated.effective_feedback) || '\u2014';
+            if (updated.instructor_feedback) {{
+                const feedbackBadge = document.createElement('span');
+                feedbackBadge.className = 'badge-override';
+                feedbackBadge.textContent = 'edited';
+                feedbackCell.appendChild(feedbackBadge);
+            }}
 
-            document.getElementById('feedback-cell-' + submissionId).textContent =
-            stripHtml(updated.effective_feedback) || '\u2014';
+            const overrideForm = gradeInput.closest('.override-form');
+            const btnRow = overrideForm.querySelector('.btn-row');
+            if (!btnRow.querySelector('.btn-revert')) {{
+                const revertBtn = document.createElement('button');
+                revertBtn.className = 'btn-revert';
+                revertBtn.textContent = 'Revert';
+                revertBtn.onclick = () => revertOverride(jobId, submissionId);
+                btnRow.appendChild(revertBtn);
+            }}
+
+
+            let overrideInfo = overrideForm.querySelector('.override-info');
+            if (!overrideInfo) {{
+                overrideInfo = document.createElement('div');
+                overrideInfo.className = 'override-info';
+                overrideInfo.style.cssText = 'font-size:0.8rem; color:#666; margin-top:4px;';
+                overrideForm.appendChild(overrideInfo);
+            }}
+            overrideInfo.textContent = 'Last override by ' + (updated.overridden_by || 'unknown');
 
         }} catch (e) {{
             msgEl.textContent = 'Could not connect. Please try again.';
@@ -843,6 +876,9 @@ document.getElementById('btn-cancel-grading').addEventListener('click', async ()
     }}
 
     async function revertOverride(jobId, submissionId, pointsPossible){{
+        if (!confirm('Are you sure you want to revert this override? The AI grade and feedback will be restored.')) {{
+            return;
+        }}
         const msgEl = document.getElementById('override-msg-' + submissionId);
         msgEl.textContent = 'Reverting...';
         msgEl.style.color = '#555';
@@ -872,6 +908,13 @@ document.getElementById('btn-cancel-grading').addEventListener('click', async ()
 
             document.getElementById('input-grade-' + submissionId).value = '';
             document.getElementById('input-feedback-' + submissionId).value = '';
+            
+            const gradeInput = document.getElementById('input-grade-' + submissionId);
+            const overrideForm = gradeInput.closest('.override-form');
+            const revertBtn = overrideForm.querySelector('.btn-revert');
+            if (revertBtn) revertBtn.remove();
+            const overrideInfo = overrideForm.querySelector('.override-info');
+            if (overrideInfo) overrideInfo.remove();
 
         }} catch (e) {{
             msgEl.textContent = 'Could not connect. Please try again.';

--- a/src/lti/ui.py
+++ b/src/lti/ui.py
@@ -98,10 +98,22 @@ def render_instructor_ui(
     .btn-link {{ background: none; border: none; color: #0066cc; cursor: pointer;
                  font-size: 0.9em; padding: 0; }}
     .btn-link:hover {{ text-decoration: underline; background: none; }}
-
+    .overridden {{ color: #0066cc; font-weight: 600; }}
+    .badge-override {{ background: #e8f0fe; color: #1a56db; font-size: 0.75em; 
+                    padding: 1px 6px; border-radius: 10px; margin-left: 4px; }}
+    .override-form {{ display: flex; flex-direction: column; gap: 4px; min-width: 160px; }}
+    .override-form input {{ padding: 4px 6px; font-size: 0.85em; border: 1px solid #ccc;
+                            border-radius: 4px; width: 70px; }}
+    .override-form textarea {{ padding: 4px 6px; font-size: 0.85em; border: 1px solid #ccc;
+                            border-radius: 4px; resize: vertical; width: 100%; }}
+    .override-form .btn-row {{ display: flex; gap: 4px; }}
+    .btn-save {{ background: #006600; padding: 3px 10px; font-size: 0.82em; }}
+    .btn-save:hover {{ background: #004d00; }}
+    .btn-revert {{ background: #cc0000; padding: 3px 10px; font-size: 0.82em; }}
+    .btn-revert:hover {{ background: #990000; }}
     #results-table td:nth-child(2),
     #results-table td:nth-child(3),
-    #results-table td:nth-child(6) {{
+    #results-table td:nth-child(7) {{
       max-width: 250px; word-break: break-word;
     }}
     #history-table tbody tr:hover {{ background: #f8f8f8; }}
@@ -199,6 +211,7 @@ def render_instructor_ui(
             <th>AI Grade</th>
             <th>Max</th>
             <th>Feedback</th>
+            <th>Override</th>
           </tr>
         </thead>
         <tbody id="results-tbody"></tbody>
@@ -534,7 +547,7 @@ def render_instructor_ui(
         const headerRow = document.createElement('tr');
         headerRow.classList.add('student-header');
         const headerTd = document.createElement('td');
-        headerTd.colSpan = 6;
+        headerTd.colSpan = 7;
         headerTd.textContent = 'Student ' + uid + '  \u2014  ' +
           studentScore.toFixed(1) + ' / ' + studentMax.toFixed(1) + ' points';
         headerRow.appendChild(headerTd);
@@ -542,19 +555,62 @@ def render_instructor_ui(
 
         studentSubs.forEach(sub => {{
           const tr = document.createElement('tr');
-          [
-            stripHtml(sub.question_name) || ('Q' + sub.question_id),
-            stripHtml(sub.question_text) || '\u2014',
-            stripHtml(sub.student_answer),
-            sub.effective_grade != null ? sub.effective_grade : '\u2014',
-            sub.points_possible,
-            stripHtml(sub.effective_feedback) || '\u2014',
-          ].forEach(val => {{
-            const td = document.createElement('td');
-            td.textContent = val;
-            tr.appendChild(td);
-          }});
-          tbody.appendChild(tr);
+          tr.dataset.submissionId = sub.submission_id;
+          
+          const tdQ = document.createElement('td');
+          tdQ.textContent = stripHtml(sub.question_name) || ('Q' + sub.question_id);
+          tr.appendChild(tdQ);
+
+          const tdQT = document.createElement('td');
+          tdQT.textContent = stripHtml(sub.question_text) || '\u2014';
+          tr.appendChild(tdQT);
+
+          const tdA = document.createElement('td');
+          tdA.textContent = stripHtml(sub.student_answer);
+          tr.appendChild(tdA);
+
+          const tdG = document.createElement('td');
+          tdG.id = 'grade-cell-' + sub.submission_id;
+          const isOverridden = sub.instructor_grade != null;
+          if (sub.effective_grade != null) {{
+              tdG.textContent = sub.effective_grade;
+              if (isOverridden) {{
+              const badge = document.createElement('span');
+              badge.className = 'badge-override';
+              badge.textContent = 'edited';
+              tdG.appendChild(badge);
+              }}
+          }} else {{
+              tdG.textContent = '\u2014';
+          }}
+          tr.appendChild(tdG);
+
+          const tdM = document.createElement('td');
+          tdM.textContent = sub.points_possible;
+          tr.appendChild(tdM);
+
+          const tdF = document.createElement('td');
+          tdF.id = 'feedback-cell-' + sub.submission_id;
+          tdF.textContent = stripHtml(sub.effective_feedback) || '\u2014';
+          tr.appendChild(tdF);
+
+          const tdO = document.createElement('td');
+          tdO.innerHTML = `
+          <div class="override-form">
+          <input type="number" id="input-grade-${{sub.submission_id}}"
+                 placeholder="Grade" min="0" max="${{sub.points_possible}}"
+                 step="0.5" value="${{sub.instructor_grade != null ? sub.instructor_grade : ''}}">
+          <textarea id="input-feedback-${{sub.submission_id}}"
+                    placeholder="Feedback" rows="2">${{sub.instructor_feedback != null ? sub.instructor_feedback : ''}}</textarea>
+          <div class="btn-row">
+          <button class="btn-save" onclick="saveOverride('${{currentJobId}}', '${{sub.submission_id}}', ${{sub.points_possible}})">Save</button>
+          ${{isOverridden ? `<button class="btn-revert" onclick="revertOverride('${{currentJobId}}', '${{sub.submission_id}}')">Revert</button>` : ''}}
+        </div>
+        <div id="override-msg-${{sub.submission_id}}" class="status"></div>
+        </div>
+        `;
+        tr.appendChild(tdO);
+        tbody.appendChild(tr);
         }});
       }});
 
@@ -724,6 +780,104 @@ document.getElementById('btn-cancel-grading').addEventListener('click', async ()
 		document.getElementById('tab-grade').innerHTML = '<div class="card"><p>You do not have permission to access this tool.</p></div>';
 	}}
     
+    async function saveOverride(jobId, submissionId, pointsPossible) {{
+        const gradeInput = document.getElementById('input-grade-' + submissionId);
+        const feedbackInput = document.getElementById('input-feedback-' + submissionId);
+        const msgEl = document.getElementById('override-msg-' + submissionId);
+
+        const grade = gradeInput.value !== '' ? parseFloat(gradeInput.value) : null;
+        const feedback = feedbackInput.value.trim() || null;
+
+        if (grade === null && feedback === null) {{
+            msgEl.textContent = 'Enter a grade or feedback to save.';
+            msgEl.style.color = '#cc0000';
+            return;
+        }}
+
+        if (grade !== null && (grade < 0 || grade > pointsPossible)) {{
+            msgEl.textContent = 'Grade must be between 0 and ' + pointsPossible + '.';
+            msgEl.style.color = '#cc0000';
+            return;
+        }}
+
+        msgEl.textContent = 'Saving...';
+        msgEl.style.color = '#555';
+
+        try {{
+            const body = {{}};
+            if (grade !== null) body.grade = grade;
+            if (feedback !== null) body.feedback = feedback;
+
+            const resp = await fetch(BASE_URL + '/jobs/' + jobId + '/submissions/' + submissionId, {{
+            method: 'PATCH',
+            headers: authHeaders(),
+            body: JSON.stringify(body),
+            }});
+
+            if (!resp.ok) {{
+            msgEl.textContent = await getErrorMessage(resp);
+            msgEl.style.color = '#cc0000';
+            return;
+            }}
+
+            const updated = await resp.json();
+            msgEl.textContent = 'Saved.';
+            msgEl.style.color = '#006600';
+
+            const gradeCell = document.getElementById('grade-cell-' + submissionId);
+            gradeCell.textContent = updated.effective_grade != null ? updated.effective_grade : '\u2014';
+            if (updated.instructor_grade != null) {{
+            const badge = document.createElement('span');
+            badge.className = 'badge-override';
+            badge.textContent = 'edited';
+            gradeCell.appendChild(badge);
+            }}
+
+            document.getElementById('feedback-cell-' + submissionId).textContent =
+            stripHtml(updated.effective_feedback) || '\u2014';
+
+        }} catch (e) {{
+            msgEl.textContent = 'Could not connect. Please try again.';
+            msgEl.style.color = '#cc0000';
+        }}
+    }}
+
+    async function revertOverride(jobId, submissionId, pointsPossible){{
+        const msgEl = document.getElementById('override-msg-' + submissionId);
+        msgEl.textContent = 'Reverting...';
+        msgEl.style.color = '#555';
+
+        try {{
+            const resp = await fetch(BASE_URL + '/jobs/' + jobId + '/submissions/' + submissionId, {{
+            method: 'PATCH',
+            headers: authHeaders(),
+            body: JSON.stringify({{ revert: true }}),
+            }});
+
+            if (!resp.ok) {{
+            msgEl.textContent = await getErrorMessage(resp);
+            msgEl.style.color = '#cc0000';
+            return;
+            }}
+
+            const updated = await resp.json();
+            msgEl.textContent = 'Reverted to AI grade.';
+            msgEl.style.color = '#006600';
+            
+            const gradeCell = document.getElementById('grade-cell-' + submissionId);
+            gradeCell.textContent = updated.effective_grade != null ? updated.effective_grade : '\u2014';
+
+            document.getElementById('feedback-cell-' + submissionId).textContent =
+            stripHtml(updated.effective_feedback) || '\u2014';
+
+            document.getElementById('input-grade-' + submissionId).value = '';
+            document.getElementById('input-feedback-' + submissionId).value = '';
+
+        }} catch (e) {{
+            msgEl.textContent = 'Could not connect. Please try again.';
+            msgEl.style.color = '#cc0000';
+        }}
+    }}
   </script>
 </body>
 </html>"""

--- a/src/lti/ui.py
+++ b/src/lti/ui.py
@@ -502,7 +502,7 @@ def render_instructor_ui(
       order.forEach(uid => {{
         let s = 0, m = 0;
         groups[uid].forEach(sub => {{
-          if (sub.ai_grade != null) s += sub.ai_grade;
+          if (sub.effective_grade != null) s += sub.effective_grade;
           m += sub.points_possible;
         }});
         if (m > 0) {{
@@ -527,7 +527,7 @@ def render_instructor_ui(
         let studentScore = 0;
         let studentMax = 0;
         studentSubs.forEach(s => {{
-          if (s.ai_grade != null) studentScore += s.ai_grade;
+          if (s.effective_grade != null) studentScore += s.effective_grade;
           studentMax += s.points_possible;
         }});
 
@@ -546,9 +546,9 @@ def render_instructor_ui(
             stripHtml(sub.question_name) || ('Q' + sub.question_id),
             stripHtml(sub.question_text) || '\u2014',
             stripHtml(sub.student_answer),
-            sub.ai_grade != null ? sub.ai_grade : '\u2014',
+            sub.effective_grade != null ? sub.effective_grade : '\u2014',
             sub.points_possible,
-            stripHtml(sub.ai_feedback) || '\u2014',
+            stripHtml(sub.effective_feedback) || '\u2014',
           ].forEach(val => {{
             const td = document.createElement('td');
             td.textContent = val;
@@ -558,7 +558,7 @@ def render_instructor_ui(
         }});
       }});
 
-      const graded = subs.filter(s => s.ai_grade != null).length;
+      const graded = subs.filter(s => s.effective_grade != null).length;
       document.getElementById('results-summary').textContent =
         graded + ' of ' + subs.length + ' answers graded.';
       document.getElementById('section-results').classList.remove('hidden');

--- a/src/lti/ui.py
+++ b/src/lti/ui.py
@@ -208,7 +208,7 @@ def render_instructor_ui(
             <th>Question</th>
             <th>Question Text</th>
             <th>Student Answer</th>
-            <th>AI Grade</th>
+            <th>Grade</th>
             <th>Max</th>
             <th>Feedback</th>
             <th>Override</th>

--- a/src/models/submission.py
+++ b/src/models/submission.py
@@ -25,3 +25,7 @@ class Submission(BaseModel):
     ai_grade: float | None = None
     ai_feedback: str | None = None
     ai_graded_at: datetime | None = None
+    instructor_grade: float | None = None
+    instructor_feedback: str | None = None
+    overridden_by: str | None = None
+    overridden_at: datetime | None = None

--- a/src/models/submission.py
+++ b/src/models/submission.py
@@ -33,7 +33,7 @@ class Submission(BaseModel):
     @computed_field
     @property
     def effective_grade(self) -> float | None:
-        if self.instructor_grade:
+        if self.instructor_grade is not None:
             return self.instructor_grade
 
         return self.ai_grade
@@ -41,7 +41,7 @@ class Submission(BaseModel):
     @computed_field
     @property
     def effective_feedback(self) -> str | None:
-        if self.instructor_feedback:
+        if self.instructor_feedback is not None:
             return self.instructor_feedback
 
         return self.ai_feedback

--- a/src/models/submission.py
+++ b/src/models/submission.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, computed_field
 
 
 class Submission(BaseModel):
@@ -29,3 +29,21 @@ class Submission(BaseModel):
     instructor_feedback: str | None = None
     overridden_by: str | None = None
     overridden_at: datetime | None = None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_grade(self) -> float | None:
+        return (
+            self.instructor_grade
+            if self.instructor_grade is not None
+            else self.ai_grade
+        )
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_feedback(self) -> str | None:
+        return (
+            self.instructor_feedback
+            if self.instructor_feedback is not None
+            else self.ai_feedback
+        )

--- a/src/models/submission.py
+++ b/src/models/submission.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field, computed_field
+from src.core.validation import validate_grade
 
 
 class Submission(BaseModel):
@@ -34,8 +35,8 @@ class Submission(BaseModel):
     @property
     def effective_grade(self) -> float | None:
         if self.instructor_grade is not None:
-            grade = max(0.0, min(self.instructor_grade, self.points_possible))
-            return grade
+            if validate_grade(self.instructor_grade, self.points_possible) is None:
+                return self.instructor_grade
 
         return self.ai_grade
 

--- a/src/models/submission.py
+++ b/src/models/submission.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field, computed_field
-from src.core.validation import validate_grade
 
 
 class Submission(BaseModel):
@@ -34,15 +33,16 @@ class Submission(BaseModel):
     @computed_field
     @property
     def effective_grade(self) -> float | None:
-        if validate_grade(self.instructor_grade) is not None:
-            return self.instructor_grade
+        if self.instructor_grade is not None:
+            grade = max(0.0, min(self.instructor_grade, self.points_possible))
+            return grade
 
         return self.ai_grade
 
     @computed_field
     @property
     def effective_feedback(self) -> str | None:
-        if validate_grade(self.instructor_feedback) is not None:
+        if self.instructor_feedback is not None and self.instructor_feedback.strip():
             return self.instructor_feedback
 
         return self.ai_feedback

--- a/src/models/submission.py
+++ b/src/models/submission.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field, computed_field
+from src.core.validation import validate_grade
 
 
 class Submission(BaseModel):
@@ -33,7 +34,7 @@ class Submission(BaseModel):
     @computed_field
     @property
     def effective_grade(self) -> float | None:
-        if self.instructor_grade is not None:
+        if validate_grade(self.instructor_grade) is not None:
             return self.instructor_grade
 
         return self.ai_grade
@@ -41,7 +42,7 @@ class Submission(BaseModel):
     @computed_field
     @property
     def effective_feedback(self) -> str | None:
-        if self.instructor_feedback is not None:
+        if validate_grade(self.instructor_feedback) is not None:
             return self.instructor_feedback
 
         return self.ai_feedback

--- a/src/models/submission.py
+++ b/src/models/submission.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, computed_field
 
 
 class Submission(BaseModel):
@@ -29,3 +29,19 @@ class Submission(BaseModel):
     instructor_feedback: str | None = None
     overridden_by: str | None = None
     overridden_at: datetime | None = None
+
+    @computed_field
+    @property
+    def effective_grade(self) -> float | None:
+        if self.instructor_grade:
+            return self.instructor_grade
+
+        return self.ai_grade
+
+    @computed_field
+    @property
+    def effective_feedback(self) -> str | None:
+        if self.instructor_feedback:
+            return self.instructor_feedback
+
+        return self.ai_feedback

--- a/src/repositories/submission.py
+++ b/src/repositories/submission.py
@@ -45,6 +45,15 @@ class SubmissionRepository:
             item["ai_feedback"] = sub.ai_feedback
         if sub.ai_graded_at is not None:
             item["ai_graded_at"] = sub.ai_graded_at.isoformat()
+            
+        if sub.instructor_grade is not None:
+            item["instructor_grade"] = str(sub.instructor_grade)
+        if sub.instructor_feedback is not None:
+            item["instructor_feedback"] = sub.instructor_feedback
+        if sub.overridden_by is not None:
+            item["overridden_by"] = sub.overridden_by
+        if sub.overridden_at is not None:
+            item["overridden_at"] = sub.overridden_at.isoformat()
         return item
 
     def _from_item(self, item: dict) -> Submission:
@@ -149,7 +158,7 @@ class SubmissionRepository:
         )
         return self.get(job_id, submission_id)
 
-    def clear_override(self, job_id: str, submission_id: str) -> Submission:
+    def clear_override(self, job_id: UUID, submission_id: UUID) -> Submission:
         self.table.update_item(
             Key={"pk": f"JOB#{job_id}", "sk": f"SUB#{submission_id}"},
             UpdateExpression="REMOVE instructor_grade, instructor_feedback, overridden_by, overridden_at",

--- a/src/repositories/submission.py
+++ b/src/repositories/submission.py
@@ -45,7 +45,7 @@ class SubmissionRepository:
             item["ai_feedback"] = sub.ai_feedback
         if sub.ai_graded_at is not None:
             item["ai_graded_at"] = sub.ai_graded_at.isoformat()
-            
+
         if sub.instructor_grade is not None:
             item["instructor_grade"] = str(sub.instructor_grade)
         if sub.instructor_feedback is not None:
@@ -144,9 +144,7 @@ class SubmissionRepository:
 
         if grade is not None:
             update_expr_parts.append("instructor_grade = :ig")
-            expr_values[":ig"] = str(
-                grade
-            )  # match your existing float-as-string convention if you use one — check ai_grade's stored type first
+            expr_values[":ig"] = str(grade)
         if feedback is not None:
             update_expr_parts.append("instructor_feedback = :ifb")
             expr_values[":ifb"] = feedback

--- a/src/repositories/submission.py
+++ b/src/repositories/submission.py
@@ -149,7 +149,7 @@ class SubmissionRepository:
         )
         return self.get(job_id, submission_id)
 
-    def clear_override(self, job_id: str, submission_id: str) -> Submission:
+    def clear_override(self, job_id: UUID, submission_id: str) -> Submission:
         self.table.update_item(
             Key={"pk": f"JOB#{job_id}", "sk": f"SUB#{submission_id}"},
             UpdateExpression="REMOVE instructor_grade, instructor_feedback, overridden_by, overridden_at",

--- a/src/repositories/submission.py
+++ b/src/repositories/submission.py
@@ -1,6 +1,6 @@
 """DynamoDB repository for Submission entities."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import UUID
 
 from boto3.dynamodb.conditions import Key
@@ -69,6 +69,16 @@ class SubmissionRepository:
                 if item.get("ai_graded_at")
                 else None
             ),
+            instructor_grade=float(item["instructor_grade"])
+            if item.get("instructor_grade")
+            else None,
+            instructor_feedback=item.get("instructor_feedback"),
+            overridden_by=item.get("overridden_by"),
+            overridden_at=(
+                datetime.fromisoformat(item["overridden_at"])
+                if item.get("overridden_at")
+                else None
+            ),
         )
 
     def batch_create(self, submissions: list[Submission]) -> None:
@@ -110,3 +120,38 @@ class SubmissionRepository:
                 ":graded_at": ai_graded_at.isoformat(),
             },
         )
+
+    def set_override(
+        self,
+        job_id: UUID,
+        submission_id: UUID,
+        grade: float | None,
+        feedback: str | None,
+        overridden_by: str,
+    ) -> Submission:
+        now = datetime.now(timezone.utc)
+        update_expr_parts = ["overridden_by = :ob", "overridden_at = :oa"]
+        expr_values = {":ob": overridden_by, ":oa": now.isoformat()}
+
+        if grade is not None:
+            update_expr_parts.append("instructor_grade = :ig")
+            expr_values[":ig"] = str(
+                grade
+            )  # match your existing float-as-string convention if you use one — check ai_grade's stored type first
+        if feedback is not None:
+            update_expr_parts.append("instructor_feedback = :ifb")
+            expr_values[":ifb"] = feedback
+
+        self.table.update_item(
+            Key={"pk": f"JOB#{job_id}", "sk": f"SUB#{submission_id}"},
+            UpdateExpression="SET " + ", ".join(update_expr_parts),
+            ExpressionAttributeValues=expr_values,
+        )
+        return self.get(job_id, submission_id)
+
+    def clear_override(self, job_id: str, submission_id: str) -> Submission:
+        self.table.update_item(
+            Key={"pk": f"JOB#{job_id}", "sk": f"SUB#{submission_id}"},
+            UpdateExpression="REMOVE instructor_grade, instructor_feedback, overridden_by, overridden_at",
+        )
+        return self.get(job_id, submission_id)

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -841,3 +841,114 @@ class TestSubmissionOverride:
             headers=auth,
         )
         assert response.status_code == 404
+
+    def test_override_revert_with_grade_returns_422(
+        self,
+        client,
+        session_token,
+        sample_canvas_data,
+        dynamodb_table,
+        instructor_launch,
+    ):
+        from uuid import UUID
+        from src.models.grading_job import JobStatus
+        from src.repositories.grading_job import GradingJobRepository
+
+        auth = {"Authorization": f"Bearer {session_token}"}
+        create = client.post(
+            "/jobs",
+            json={
+                "course_id": "C100",
+                "quiz_id": "Q50",
+                "job_name": "Test Job",
+                "canvas_data": sample_canvas_data,
+            },
+            headers=auth,
+        )
+        job_id = create.json()["job_id"]
+        GradingJobRepository(table=dynamodb_table).update_status(
+            UUID(job_id), JobStatus.COMPLETED
+        )
+        subs = client.get(f"/jobs/{job_id}/submissions", headers=auth).json()
+        submission_id = subs[0]["submission_id"]
+
+        response = client.patch(
+            f"/jobs/{job_id}/submissions/{submission_id}",
+            json={"grade": 1, "revert": True},
+            headers=auth,
+        )
+        assert response.status_code == 422
+
+    def test_override_negative_grade_returns_422(
+        self,
+        client,
+        session_token,
+        sample_canvas_data,
+        dynamodb_table,
+        instructor_launch,
+    ):
+        from uuid import UUID
+        from src.models.grading_job import JobStatus
+        from src.repositories.grading_job import GradingJobRepository
+
+        auth = {"Authorization": f"Bearer {session_token}"}
+        create = client.post(
+            "/jobs",
+            json={
+                "course_id": "C100",
+                "quiz_id": "Q50",
+                "job_name": "Test Job",
+                "canvas_data": sample_canvas_data,
+            },
+            headers=auth,
+        )
+        job_id = create.json()["job_id"]
+        GradingJobRepository(table=dynamodb_table).update_status(
+            UUID(job_id), JobStatus.COMPLETED
+        )
+        subs = client.get(f"/jobs/{job_id}/submissions", headers=auth).json()
+        submission_id = subs[0]["submission_id"]
+
+        response = client.patch(
+            f"/jobs/{job_id}/submissions/{submission_id}",
+            json={"grade": -1},
+            headers=auth,
+        )
+        assert response.status_code == 422
+
+    def test_override_empty_feedback_returns_422(
+        self,
+        client,
+        session_token,
+        sample_canvas_data,
+        dynamodb_table,
+        instructor_launch,
+    ):
+        from uuid import UUID
+        from src.models.grading_job import JobStatus
+        from src.repositories.grading_job import GradingJobRepository
+
+        auth = {"Authorization": f"Bearer {session_token}"}
+        create = client.post(
+            "/jobs",
+            json={
+                "course_id": "C100",
+                "quiz_id": "Q50",
+                "job_name": "Test Job",
+                "canvas_data": sample_canvas_data,
+            },
+            headers=auth,
+        )
+        job_id = create.json()["job_id"]
+        GradingJobRepository(table=dynamodb_table).update_status(
+            UUID(job_id), JobStatus.COMPLETED
+        )
+        subs = client.get(f"/jobs/{job_id}/submissions", headers=auth).json()
+        submission_id = subs[0]["submission_id"]
+
+        response = client.patch(
+            f"/jobs/{job_id}/submissions/{submission_id}",
+            json={"feedback": "   "},
+            headers=auth,
+        )
+        assert response.status_code == 422

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -317,3 +317,23 @@ class TestListSubmissions:
             headers={"Authorization": f"Bearer {session_token}"},
         )
         assert response.status_code == 403
+
+
+# class TestJobOverride:
+#     def test_override_submission_out_of_range(self, client):
+#         resp = client.patch(
+#             f"/jobs/{job_id}/submissions/{submission_id}",
+#             json={"grade": 9999},
+#             headers=auth_headers,
+#         )
+#         assert resp.status_code == 422
+
+
+# # def test_override_submission_job_not_completed(self, client):
+# #     # job with status PENDING or PROCESSING
+# #     resp = client.patch(...)
+# #     assert resp.status_code == 409
+
+# # def test_override_submission_wrong_course(self, client):
+# #     resp = client.patch(..., headers=other_course_auth_headers)
+# #     assert resp.status_code == 403

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -462,3 +462,21 @@ class TestCancelJob:
         )
         assert response.status_code == 200
         assert response.json()["status"] == "CANCELLED"
+# class TestJobOverride:
+#     def test_override_submission_out_of_range(self, client):
+#         resp = client.patch(
+#             f"/jobs/{job_id}/submissions/{submission_id}",
+#             json={"grade": 9999},
+#             headers=auth_headers,
+#         )
+#         assert resp.status_code == 422
+
+
+# # def test_override_submission_job_not_completed(self, client):
+# #     # job with status PENDING or PROCESSING
+# #     resp = client.patch(...)
+# #     assert resp.status_code == 409
+
+# # def test_override_submission_wrong_course(self, client):
+# #     resp = client.patch(..., headers=other_course_auth_headers)
+# #     assert resp.status_code == 403

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -462,21 +462,382 @@ class TestCancelJob:
         )
         assert response.status_code == 200
         assert response.json()["status"] == "CANCELLED"
-# class TestJobOverride:
-#     def test_override_submission_out_of_range(self, client):
-#         resp = client.patch(
-#             f"/jobs/{job_id}/submissions/{submission_id}",
-#             json={"grade": 9999},
-#             headers=auth_headers,
-#         )
-#         assert resp.status_code == 422
 
 
-# # def test_override_submission_job_not_completed(self, client):
-# #     # job with status PENDING or PROCESSING
-# #     resp = client.patch(...)
-# #     assert resp.status_code == 409
+class TestSubmissionOverride:
+    def test_override_submission_updates_grade(
+        self,
+        client,
+        session_token,
+        sample_canvas_data,
+        dynamodb_table,
+        instructor_launch,
+    ):
+        from uuid import UUID
 
-# # def test_override_submission_wrong_course(self, client):
-# #     resp = client.patch(..., headers=other_course_auth_headers)
-# #     assert resp.status_code == 403
+        from src.models.grading_job import JobStatus
+        from src.repositories.grading_job import GradingJobRepository
+        from src.repositories.submission import SubmissionRepository
+
+        auth = {"Authorization": f"Bearer {session_token}"}
+
+        create = client.post(
+            "/jobs",
+            json={
+                "course_id": "C100",
+                "quiz_id": "Q50",
+                "job_name": "Test Job",
+                "canvas_data": sample_canvas_data,
+            },
+            headers=auth,
+        )
+
+        job_id = create.json()["job_id"]
+
+        GradingJobRepository(table=dynamodb_table).update_status(
+            UUID(job_id),
+            JobStatus.COMPLETED,
+        )
+
+        submission = client.get(
+            f"/jobs/{job_id}/submissions",
+            headers=auth,
+        ).json()[0]
+
+        submission_id = submission["submission_id"]
+
+        response = client.patch(
+            f"/jobs/{job_id}/submissions/{submission_id}",
+            json={
+                "grade": 5,
+                "feedback": "Great answer",
+            },
+            headers=auth,
+        )
+
+        assert response.status_code == 200
+
+        repo = SubmissionRepository(table=dynamodb_table)
+
+        updated = repo.get(
+            UUID(job_id),
+            UUID(submission_id),
+        )
+
+        assert updated.instructor_grade == 5
+        assert updated.instructor_feedback == "Great answer"
+
+    def test_override_submission_success(
+        self,
+        client,
+        session_token,
+        sample_canvas_data,
+        dynamodb_table,
+        instructor_launch,
+    ):
+        from uuid import UUID
+
+        from src.models.grading_job import JobStatus
+        from src.repositories.grading_job import GradingJobRepository
+
+        auth = {"Authorization": f"Bearer {session_token}"}
+
+        create = client.post(
+            "/jobs",
+            json={
+                "course_id": "C100",
+                "quiz_id": "Q50",
+                "job_name": "Test Job",
+                "canvas_data": sample_canvas_data,
+            },
+            headers=auth,
+        )
+
+        job_id = create.json()["job_id"]
+
+        repo = GradingJobRepository(table=dynamodb_table)
+        repo.update_status(UUID(job_id), JobStatus.COMPLETED)
+
+        subs = client.get(
+            f"/jobs/{job_id}/submissions",
+            headers=auth,
+        ).json()
+
+        submission_id = subs[0]["submission_id"]
+
+        response = client.patch(
+            f"/jobs/{job_id}/submissions/{submission_id}",
+            json={
+                "grade": 4,
+                "feedback": "Excellent work.",
+            },
+            headers=auth,
+        )
+        assert response.status_code == 200
+
+        data = response.json()
+
+        assert data["instructor_grade"] == 4
+        assert data["instructor_feedback"] == "Excellent work."
+
+        assert data["effective_grade"] == 4
+        assert data["effective_feedback"] == "Excellent work."
+
+        assert data["overridden_by"] != ""
+        assert data["overridden_at"] is not None
+
+    def test_override_submission_out_of_range(
+        self,
+        client,
+        session_token,
+        sample_canvas_data,
+        dynamodb_table,
+        instructor_launch,
+    ):
+        from uuid import UUID
+
+        from src.models.grading_job import JobStatus
+        from src.repositories.grading_job import GradingJobRepository
+
+        auth = {"Authorization": f"Bearer {session_token}"}
+
+        create = client.post(
+            "/jobs",
+            json={
+                "course_id": "C100",
+                "quiz_id": "Q50",
+                "job_name": "Test Job",
+                "canvas_data": sample_canvas_data,
+            },
+            headers=auth,
+        )
+
+        job_id = create.json()["job_id"]
+
+        repo = GradingJobRepository(table=dynamodb_table)
+        repo.update_status(UUID(job_id), JobStatus.COMPLETED)
+
+        subs = client.get(
+            f"/jobs/{job_id}/submissions",
+            headers=auth,
+        ).json()
+
+        submission_id = subs[0]["submission_id"]
+
+        response = client.patch(
+            f"/jobs/{job_id}/submissions/{submission_id}",
+            json={"grade": 9999},
+            headers=auth,
+        )
+
+        assert response.status_code == 422
+
+    def test_override_submission_job_not_completed(
+        self,
+        client,
+        session_token,
+        sample_canvas_data,
+        instructor_launch,
+    ):
+        auth = {"Authorization": f"Bearer {session_token}"}
+
+        create = client.post(
+            "/jobs",
+            json={
+                "course_id": "C100",
+                "quiz_id": "Q50",
+                "job_name": "Test Job",
+                "canvas_data": sample_canvas_data,
+            },
+            headers=auth,
+        )
+
+        job_id = create.json()["job_id"]
+
+        subs = client.get(
+            f"/jobs/{job_id}/submissions",
+            headers=auth,
+        ).json()
+
+        submission_id = subs[0]["submission_id"]
+
+        response = client.patch(
+            f"/jobs/{job_id}/submissions/{submission_id}",
+            json={"grade": 5},
+            headers=auth,
+        )
+
+        assert response.status_code == 409
+
+    def test_override_submission_wrong_course(
+        self,
+        client,
+        session_token,
+        dynamodb_table,
+        instructor_launch,
+    ):
+        from src.models.grading_job import GradingJob, JobStatus
+        from src.models.submission import Submission
+        from src.repositories.grading_job import GradingJobRepository
+        from src.repositories.submission import SubmissionRepository
+
+        job_repo = GradingJobRepository(table=dynamodb_table)
+
+        job = GradingJob(
+            course_id="OTHER",
+            quiz_id="Q50",
+            job_name="Other Job",
+            status=JobStatus.COMPLETED,
+        )
+        job_repo.create(job)
+
+        sub = Submission(
+            job_id=job.job_id,
+            question_id=1,
+            question_name="Q1",
+            question_type="essay_question",
+            question_text="Question",
+            points_possible=10,
+            student_answer="Answer",
+            canvas_points=0,
+            correct_answers=[],
+        )
+
+        SubmissionRepository(table=dynamodb_table).batch_create([sub])
+
+        response = client.patch(
+            f"/jobs/{job.job_id}/submissions/{sub.submission_id}",
+            json={"grade": 8},
+            headers={"Authorization": f"Bearer {session_token}"},
+        )
+
+        assert response.status_code == 403
+
+    def test_override_submission_revert(
+        self,
+        client,
+        session_token,
+        sample_canvas_data,
+        dynamodb_table,
+        instructor_launch,
+    ):
+        from uuid import UUID
+        from src.models.grading_job import JobStatus
+        from src.repositories.grading_job import GradingJobRepository
+        from src.repositories.submission import SubmissionRepository
+
+        auth = {"Authorization": f"Bearer {session_token}"}
+
+        create = client.post(
+            "/jobs",
+            json={
+                "course_id": "C100",
+                "quiz_id": "Q50",
+                "job_name": "Test Job",
+                "canvas_data": sample_canvas_data,
+            },
+            headers=auth,
+        )
+        job_id = create.json()["job_id"]
+        GradingJobRepository(table=dynamodb_table).update_status(
+            UUID(job_id), JobStatus.COMPLETED
+        )
+
+        subs = client.get(f"/jobs/{job_id}/submissions", headers=auth).json()
+        submission_id = subs[0]["submission_id"]
+
+        # First set an override
+        client.patch(
+            f"/jobs/{job_id}/submissions/{submission_id}",
+            json={"grade": 8, "feedback": "Good"},
+            headers=auth,
+        )
+
+        # Then revert it
+        response = client.patch(
+            f"/jobs/{job_id}/submissions/{submission_id}",
+            json={"revert": True},
+            headers=auth,
+        )
+        assert response.status_code == 200
+
+        repo = SubmissionRepository(table=dynamodb_table)
+        updated = repo.get(UUID(job_id), UUID(submission_id))
+        assert updated.instructor_grade is None
+        assert updated.instructor_feedback is None
+        assert updated.overridden_by is None
+
+    def test_override_submission_nothing_to_update(
+        self,
+        client,
+        session_token,
+        sample_canvas_data,
+        dynamodb_table,
+        instructor_launch,
+    ):
+        from uuid import UUID
+        from src.models.grading_job import JobStatus
+        from src.repositories.grading_job import GradingJobRepository
+
+        auth = {"Authorization": f"Bearer {session_token}"}
+
+        create = client.post(
+            "/jobs",
+            json={
+                "course_id": "C100",
+                "quiz_id": "Q50",
+                "job_name": "Test Job",
+                "canvas_data": sample_canvas_data,
+            },
+            headers=auth,
+        )
+        job_id = create.json()["job_id"]
+        GradingJobRepository(table=dynamodb_table).update_status(
+            UUID(job_id), JobStatus.COMPLETED
+        )
+
+        subs = client.get(f"/jobs/{job_id}/submissions", headers=auth).json()
+        submission_id = subs[0]["submission_id"]
+
+        response = client.patch(
+            f"/jobs/{job_id}/submissions/{submission_id}",
+            json={},
+            headers=auth,
+        )
+        assert response.status_code == 422
+
+    def test_override_submission_not_found(
+        self,
+        client,
+        session_token,
+        sample_canvas_data,
+        dynamodb_table,
+        instructor_launch,
+    ):
+        from uuid import UUID, uuid4
+        from src.models.grading_job import JobStatus
+        from src.repositories.grading_job import GradingJobRepository
+
+        auth = {"Authorization": f"Bearer {session_token}"}
+
+        create = client.post(
+            "/jobs",
+            json={
+                "course_id": "C100",
+                "quiz_id": "Q50",
+                "job_name": "Test Job",
+                "canvas_data": sample_canvas_data,
+            },
+            headers=auth,
+        )
+        job_id = create.json()["job_id"]
+        GradingJobRepository(table=dynamodb_table).update_status(
+            UUID(job_id), JobStatus.COMPLETED
+        )
+
+        response = client.patch(
+            f"/jobs/{job_id}/submissions/{uuid4()}",
+            json={"grade": 5},
+            headers=auth,
+        )
+        assert response.status_code == 404

--- a/tests/test_lti_ags.py
+++ b/tests/test_lti_ags.py
@@ -805,59 +805,61 @@ class TestPassbackQuizGradesViaRest:
         assert sent_questions[1]["score"] == 9.0  # instructor override, not 6.0
         assert sent_questions[1]["comment"] == "Instructor feedback"
 
-    # def test_passback_rest_falls_back_to_ai_grade_without_override(self, monkeypatch):
-    #     from uuid import uuid4
-    #     from src.models.submission import Submission
-    #     from src.lti.ags import passback_quiz_grades_via_rest
+    def test_passback_rest_falls_back_to_ai_grade_without_override(self, monkeypatch):
+        from uuid import uuid4
+        from src.models.submission import Submission
+        from src.lti.ags import passback_quiz_grades_via_rest
 
-    #     job_id = uuid4()
-    #     sub = Submission(
-    #         job_id=job_id,
-    #         question_id=1,
-    #         question_name="Q1",
-    #         question_type="essay_question",
-    #         question_text="text",
-    #         points_possible=10.0,
-    #         student_answer="answer",
-    #         canvas_points=0.0,
-    #         correct_answers=[],
-    #         canvas_user_id="u1",
-    #         quiz_submission_id=55,
-    #         attempt=1,
-    #         ai_grade=6.0,
-    #         ai_feedback="AI feedback",
-    #         # no override fields set
-    #     )
+        job_id = uuid4()
+        sub = Submission(
+            job_id=job_id,
+            question_id=1,
+            question_name="Q1",
+            question_type="essay_question",
+            question_text="text",
+            points_possible=10.0,
+            student_answer="answer",
+            canvas_points=0.0,
+            correct_answers=[],
+            canvas_user_id="u1",
+            quiz_submission_id=55,
+            attempt=1,
+            ai_grade=6.0,
+            ai_feedback="AI feedback",
+        )
 
-    #     class FakeRepo:
-    #         def list_by_job(self, jid):
-    #             return [sub]
+        class FakeRepo:
+            def list_by_job(self, jid):
+                return [sub]
 
-    #     calls = []
+        calls = []
 
-    #     class FakeClient:
-    #         def __init__(self, *a, **k):
-    #             pass
+        class FakeClient:
+            def __init__(self, *a, **k):
+                pass
 
-    #         def __enter__(self):
-    #             return self
+            def __enter__(self):
+                return self
 
-    #         def __exit__(self, *a):
-    #             pass
+            def __exit__(self, *a):
+                pass
 
-    #         def update_quiz_submission_scores(self, **kwargs):
-    #             calls.append(kwargs)
+            def update_quiz_submission_scores(self, **kwargs):
+                calls.append(kwargs)
 
-    #     monkeypatch.setattr("src.lti.canvas_api.CanvasAPIClient", FakeClient)
+        monkeypatch.setattr("src.lti.canvas_api.CanvasAPIClient", FakeClient)
 
-    #     result = passback_quiz_grades_via_rest(
-    #         job_id=str(job_id),
-    #         quiz_id="1",
-    #         course_id="1",
-    #         canvas_token="tok",
-    #         canvas_url="https://canvas.example.com",
-    #         submission_repo=FakeRepo(),
-    #     )
+        result = passback_quiz_grades_via_rest(
+            job_id=str(job_id),
+            quiz_id="1",
+            course_id="1",
+            canvas_token="tok",
+            canvas_url="https://canvas.example.com",
+            submission_repo=FakeRepo(),
+        )
 
-    #     sent_questions = calls[0]["questions"]
-    #     assert sent_questions[1]["score"] == 6.0  # falls back to AI grade
+        sent_questions = calls[0]["questions"]
+        assert sent_questions[1]["score"] == 6.0
+        assert result["submitted"] == 1
+        assert calls[0]["questions"][1]["score"] == 6.0
+        assert calls[0]["questions"][1]["comment"] == "AI feedback"

--- a/tests/test_lti_ags.py
+++ b/tests/test_lti_ags.py
@@ -744,3 +744,120 @@ class TestPassbackQuizGradesViaRest:
         assert result["submitted"] == 0
         assert len(result["errors"]) == 1
         assert "Canvas 403 Forbidden" in result["errors"][0]
+
+    def test_passback_rest_uses_effective_grade_with_override(self, monkeypatch):
+        from uuid import uuid4
+        from src.models.submission import Submission
+        from src.lti.ags import passback_quiz_grades_via_rest
+
+        job_id = uuid4()
+        sub = Submission(
+            job_id=job_id,
+            question_id=1,
+            question_name="Q1",
+            question_type="essay_question",
+            question_text="text",
+            points_possible=10.0,
+            student_answer="answer",
+            canvas_points=0.0,
+            correct_answers=[],
+            canvas_user_id="u1",
+            quiz_submission_id=55,
+            attempt=1,
+            ai_grade=6.0,
+            ai_feedback="AI feedback",
+            instructor_grade=9.0,
+            instructor_feedback="Instructor feedback",
+        )
+
+        class FakeRepo:
+            def list_by_job(self, jid):
+                return [sub]
+
+        calls = []
+
+        class FakeClient:
+            def __init__(self, *a, **k):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+            def update_quiz_submission_scores(self, **kwargs):
+                calls.append(kwargs)
+
+        monkeypatch.setattr("src.lti.canvas_api.CanvasAPIClient", FakeClient)
+
+        result = passback_quiz_grades_via_rest(
+            job_id=str(job_id),
+            quiz_id="1",
+            course_id="1",
+            canvas_token="tok",
+            canvas_url="https://canvas.example.com",
+            submission_repo=FakeRepo(),
+        )
+
+        assert result["submitted"] == 1
+        sent_questions = calls[0]["questions"]
+        assert sent_questions[1]["score"] == 9.0  # instructor override, not 6.0
+        assert sent_questions[1]["comment"] == "Instructor feedback"
+
+    # def test_passback_rest_falls_back_to_ai_grade_without_override(self, monkeypatch):
+    #     from uuid import uuid4
+    #     from src.models.submission import Submission
+    #     from src.lti.ags import passback_quiz_grades_via_rest
+
+    #     job_id = uuid4()
+    #     sub = Submission(
+    #         job_id=job_id,
+    #         question_id=1,
+    #         question_name="Q1",
+    #         question_type="essay_question",
+    #         question_text="text",
+    #         points_possible=10.0,
+    #         student_answer="answer",
+    #         canvas_points=0.0,
+    #         correct_answers=[],
+    #         canvas_user_id="u1",
+    #         quiz_submission_id=55,
+    #         attempt=1,
+    #         ai_grade=6.0,
+    #         ai_feedback="AI feedback",
+    #         # no override fields set
+    #     )
+
+    #     class FakeRepo:
+    #         def list_by_job(self, jid):
+    #             return [sub]
+
+    #     calls = []
+
+    #     class FakeClient:
+    #         def __init__(self, *a, **k):
+    #             pass
+
+    #         def __enter__(self):
+    #             return self
+
+    #         def __exit__(self, *a):
+    #             pass
+
+    #         def update_quiz_submission_scores(self, **kwargs):
+    #             calls.append(kwargs)
+
+    #     monkeypatch.setattr("src.lti.canvas_api.CanvasAPIClient", FakeClient)
+
+    #     result = passback_quiz_grades_via_rest(
+    #         job_id=str(job_id),
+    #         quiz_id="1",
+    #         course_id="1",
+    #         canvas_token="tok",
+    #         canvas_url="https://canvas.example.com",
+    #         submission_repo=FakeRepo(),
+    #     )
+
+    #     sent_questions = calls[0]["questions"]
+    #     assert sent_questions[1]["score"] == 6.0  # falls back to AI grade

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -330,12 +330,15 @@ class TestSubmissionRepository:
             overridden_by="instructor_123",
         )
         assert updated.instructor_grade == 8.5
+        assert updated.instructor_feedback == "Good work but check citation 3"
         assert updated.overridden_by == "instructor_123"
         assert updated.effective_grade == 8.5
+        assert updated.effective_feedback == "Good work but check citation 3"
 
         cleared = repo.clear_override(job_id, sub.submission_id)
         assert cleared.instructor_grade is None
         assert cleared.effective_grade == cleared.ai_grade
+        assert cleared.effective_feedback == cleared.ai_feedback
 
     def test_override_persists_across_separate_get(self, dynamodb_table):
         repo = SubmissionRepository(table=dynamodb_table)
@@ -367,3 +370,4 @@ class TestSubmissionRepository:
         assert refetched.instructor_feedback == "Check citation 3"
         assert refetched.overridden_by == "instructor_123"
         assert refetched.effective_grade == 8.5
+        assert refetched.effective_feedback == "Check citation 3"

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -303,3 +303,67 @@ class TestSubmissionRepository:
         result = repo.get(job_id, sub.submission_id)
         assert result.points_possible == 3.14
         assert result.canvas_points == 2.71
+
+    def test_set_and_clear_override(self, dynamodb_table):
+        repo = SubmissionRepository(table=dynamodb_table)
+        job_id = uuid4()
+        sub = Submission(
+            job_id=job_id,
+            question_id=101,
+            question_name="Q1",
+            question_type="short_answer_question",
+            question_text="What is X?",
+            points_possible=10.0,
+            student_answer="My answer",
+            canvas_points=5.0,
+            correct_answers=["X"],
+            ai_grade=6.0,
+            ai_feedback="AI feedback",
+        )
+        repo.batch_create([sub])
+
+        updated = repo.set_override(
+            job_id,
+            sub.submission_id,
+            grade=8.5,
+            feedback="Good work but check citation 3",
+            overridden_by="instructor_123",
+        )
+        assert updated.instructor_grade == 8.5
+        assert updated.overridden_by == "instructor_123"
+        assert updated.effective_grade == 8.5
+
+        cleared = repo.clear_override(job_id, sub.submission_id)
+        assert cleared.instructor_grade is None
+        assert cleared.effective_grade == cleared.ai_grade
+
+    def test_override_persists_across_separate_get(self, dynamodb_table):
+        repo = SubmissionRepository(table=dynamodb_table)
+        job_id = uuid4()
+        sub = Submission(
+            job_id=job_id,
+            question_id=101,
+            question_name="Q1",
+            question_type="short_answer_question",
+            question_text="What is X?",
+            points_possible=10.0,
+            student_answer="My answer",
+            canvas_points=5.0,
+            correct_answers=["X"],
+            ai_grade=6.0,
+            ai_feedback="AI feedback",
+        )
+        repo.batch_create([sub])
+
+        repo.set_override(
+            job_id,
+            sub.submission_id,
+            grade=8.5,
+            feedback="Check citation 3",
+            overridden_by="instructor_123",
+        )
+        refetched = repo.get(job_id, sub.submission_id)
+        assert refetched.instructor_grade == 8.5
+        assert refetched.instructor_feedback == "Check citation 3"
+        assert refetched.overridden_by == "instructor_123"
+        assert refetched.effective_grade == 8.5


### PR DESCRIPTION
## Summary
Add the human in the loop feature, allowing instructors to review AI generated 
grades and feedback after a grading job completes, override individual submissions, 
and revert overrides back to the original AI result. If an instructor does not 
override a submission, the AI grade and feedback are used when pushing to Canvas.

## Changes
- Added instructor override fields to the Submission model 
  (instructor_grade, instructor_feedback, overridden_by, overridden_at) 
  and two computed fields (effective_grade, effective_feedback) that return 
  the instructor value if set, otherwise the AI value
- Added PATCH /jobs/{job_id}/submissions/{submission_id} endpoint with 
  course scoped access control, grade range validation, and revert option
- Added SubmissionRepository.set_override() and clear_override() methods
- Added src/core/validation.py with validate_grade() for reusable grade validation
- Updated the results table in the frontend to show an override form per 
  submission with Save and Revert buttons, and an "edited" badge on overridden grades
- Renamed the results table column name from `AI Grade` to `Grade` 
- Added TestSubmissionOverride test class covering success, revert, validation, 
  access control, and edge cases
- Updated API reference and data model documentation